### PR TITLE
Removing extra braces from text output.

### DIFF
--- a/reference_handler/reference_handler.py
+++ b/reference_handler/reference_handler.py
@@ -110,6 +110,9 @@ class Reference_Handler(object):
                     else:
                         plain_text = fstring.format(**parse)
 
+                    # BibTex may have lots of braces ... so remove them
+                    plain_text = plain_text.replace('{', '').replace('}', '')
+
                     ret.append((item[0], plain_text, item[2], item[3]))
                 except KeyError:
                     pprint.pprint(parse)


### PR DESCRIPTION
## Description
Remove extra braces in the text output. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Cleanup the text output of the references. BibTex allows braces around one or more characters to protect them, and some references use this liberally, making it hard to read the plain text.

## Questions
- [ ] At the moment I simply remove all braces '{}' from the text. This generally works but may be too much. It appears that BibTex allows braces to quote braces, so perhaps we need a bit more carefully approach at some time. This is, however, a first step.

## Status
- [x] Ready to go